### PR TITLE
Use a set for storing unique items

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -42,13 +42,13 @@ impl BeginAuthentication {
 
         let method = url("/oauth/request");
         let mut res = client.post(method)
-                            .body(&format!("consumer_key={}&redirect_uri={}",
-                                           &self.consumer_key,
-                                           REDIRECT_URL))
-                            .header(ContentType::form_url_encoded())
-                            .header(Connection::close())
-                            .send()
-                            .unwrap();
+            .body(&format!("consumer_key={}&redirect_uri={}",
+                           &self.consumer_key,
+                           REDIRECT_URL))
+            .header(ContentType::form_url_encoded())
+            .header(Connection::close())
+            .send()
+            .unwrap();
 
         let mut body = String::new();
         res.read_to_string(&mut body).unwrap();
@@ -79,13 +79,13 @@ impl AuthorizationRequest {
 
         let method = url("/oauth/authorize");
         let mut res = client.post(method)
-                            .body(&format!("consumer_key={}&code={}",
-                                           &self.consumer_key,
-                                           &self.request_code))
-                            .header(ContentType::form_url_encoded())
-                            .header(Connection::close())
-                            .send()
-                            .unwrap();
+            .body(&format!("consumer_key={}&code={}",
+                           &self.consumer_key,
+                           &self.request_code))
+            .header(ContentType::form_url_encoded())
+            .header(Connection::close())
+            .send()
+            .unwrap();
 
         let mut body = String::new();
         res.read_to_string(&mut body).unwrap();

--- a/src/bin/pickpocket-auth.rs
+++ b/src/bin/pickpocket-auth.rs
@@ -23,7 +23,7 @@ fn consumer_key() -> String {
 
 fn main() {
     let authorization_request = BeginAuthentication { consumer_key: consumer_key() }
-                                    .request_authorization_code();
+        .request_authorization_code();
 
     println!("Please visit {}", authorization_request.authorization_url());
     println!("Press enter after authorizing with Pocket");

--- a/src/bin/pickpocket-batch-add.rs
+++ b/src/bin/pickpocket-batch-add.rs
@@ -2,7 +2,7 @@ extern crate hyper;
 extern crate rustc_serialize;
 extern crate pickpocket;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeSet};
 use std::env;
 use std::io::{BufReader, BufRead};
 
@@ -26,12 +26,12 @@ fn main() {
         url_id.insert(&reading_item.url(), id);
     }
 
-    let mut urls: Vec<String> = Vec::new();
+    let mut urls: BTreeSet<String> = BTreeSet::new();
 
     for line in BufReader::new(file).lines() {
         let url = line.expect("Couldn't read line from Buffered Reader");
         match url_id.get(&url as &str) {
-            None => urls.push(url),
+            None => { urls.insert(url); },
             Some(_) => println!("Url {} already there. Not adding.", &url),
         }
     }

--- a/src/bin/pickpocket-batch-add.rs
+++ b/src/bin/pickpocket-batch-add.rs
@@ -36,5 +36,5 @@ fn main() {
         }
     }
 
-    client.add_urls(&urls.iter().map(AsRef::as_ref).collect::<Vec<&str>>());
+    client.add_urls(urls.iter().map(AsRef::as_ref));
 }

--- a/src/bin/pickpocket-batch-add.rs
+++ b/src/bin/pickpocket-batch-add.rs
@@ -2,7 +2,7 @@ extern crate hyper;
 extern crate rustc_serialize;
 extern crate pickpocket;
 
-use std::collections::{HashMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::io::{BufReader, BufRead};
 
@@ -21,7 +21,7 @@ fn main() {
 
     let reading_list = client.list_all();
 
-    let mut url_id: HashMap<&str, &str> = HashMap::new();
+    let mut url_id: BTreeMap<&str, &str> = BTreeMap::new();
     for (id, reading_item) in &reading_list.list {
         url_id.insert(&reading_item.url(), id);
     }

--- a/src/bin/pickpocket-batch-add.rs
+++ b/src/bin/pickpocket-batch-add.rs
@@ -8,9 +8,9 @@ use std::io::{BufReader, BufRead};
 
 fn main() {
     let file_name = env::args()
-                        .skip(1)
-                        .next()
-                        .expect("Expected an file as argument");
+        .skip(1)
+        .next()
+        .expect("Expected an file as argument");
 
     let file = std::fs::File::open(&file_name).expect(&format!("Couldn't open {}", &file_name));
 
@@ -31,7 +31,9 @@ fn main() {
     for line in BufReader::new(file).lines() {
         let url = line.expect("Couldn't read line from Buffered Reader");
         match url_id.get(&url as &str) {
-            None => { urls.insert(url); },
+            None => {
+                urls.insert(url);
+            }
             Some(_) => println!("Url {} already there. Not adding.", &url),
         }
     }

--- a/src/bin/pickpocket-batch-favorite.rs
+++ b/src/bin/pickpocket-batch-favorite.rs
@@ -8,9 +8,9 @@ use std::io::{BufReader, BufRead};
 
 fn main() {
     let file_name = env::args()
-                        .skip(1)
-                        .next()
-                        .expect("Expected an file as argument");
+        .skip(1)
+        .next()
+        .expect("Expected an file as argument");
 
     let file = std::fs::File::open(&file_name).expect(&format!("Couldn't open {}", &file_name));
 
@@ -31,7 +31,9 @@ fn main() {
     for line in BufReader::new(file).lines() {
         let url = line.expect("Couldn't read line from Buffered Reader");
         match url_id.get(&url as &str) {
-            Some(id) => { ids.insert(id); },
+            Some(id) => {
+                ids.insert(id);
+            }
             None => println!("Url {} did not match", &url),
         }
     }

--- a/src/bin/pickpocket-batch-favorite.rs
+++ b/src/bin/pickpocket-batch-favorite.rs
@@ -2,7 +2,7 @@ extern crate hyper;
 extern crate rustc_serialize;
 extern crate pickpocket;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeSet};
 use std::env;
 use std::io::{BufReader, BufRead};
 
@@ -26,12 +26,12 @@ fn main() {
         url_id.insert(&reading_item.url(), id);
     }
 
-    let mut ids: Vec<&str> = Vec::new();
+    let mut ids: BTreeSet<&str> = BTreeSet::new();
 
     for line in BufReader::new(file).lines() {
         let url = line.expect("Couldn't read line from Buffered Reader");
         match url_id.get(&url as &str) {
-            Some(id) => ids.push(id),
+            Some(id) => { ids.insert(id); },
             None => println!("Url {} did not match", &url),
         }
     }

--- a/src/bin/pickpocket-batch-favorite.rs
+++ b/src/bin/pickpocket-batch-favorite.rs
@@ -2,7 +2,7 @@ extern crate hyper;
 extern crate rustc_serialize;
 extern crate pickpocket;
 
-use std::collections::{HashMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::io::{BufReader, BufRead};
 
@@ -21,7 +21,7 @@ fn main() {
 
     let reading_list = client.list_all();
 
-    let mut url_id: HashMap<&str, &str> = HashMap::new();
+    let mut url_id: BTreeMap<&str, &str> = BTreeMap::new();
     for (id, reading_item) in &reading_list.list {
         url_id.insert(&reading_item.url(), id);
     }

--- a/src/bin/pickpocket-batch-favorite.rs
+++ b/src/bin/pickpocket-batch-favorite.rs
@@ -36,5 +36,5 @@ fn main() {
         }
     }
 
-    client.mark_as_favorite(&ids);
+    client.mark_as_favorite(ids);
 }

--- a/src/bin/pickpocket-batch-read.rs
+++ b/src/bin/pickpocket-batch-read.rs
@@ -8,9 +8,9 @@ use std::io::{BufReader, BufRead};
 
 fn main() {
     let file_name = env::args()
-                        .skip(1)
-                        .next()
-                        .expect("Expected an file as argument");
+        .skip(1)
+        .next()
+        .expect("Expected an file as argument");
 
     let file = std::fs::File::open(&file_name).expect(&format!("Couldn't open {}", &file_name));
 
@@ -31,7 +31,9 @@ fn main() {
     for line in BufReader::new(file).lines() {
         let url = line.expect("Couldn't read line from Buffered Reader");
         match url_id.get(&url as &str) {
-            Some(id) => { ids.insert(id); },
+            Some(id) => {
+                ids.insert(id);
+            }
             None => println!("Url {} did not match", &url),
         }
     }

--- a/src/bin/pickpocket-batch-read.rs
+++ b/src/bin/pickpocket-batch-read.rs
@@ -36,5 +36,5 @@ fn main() {
         }
     }
 
-    client.mark_as_read(&ids);
+    client.mark_as_read(ids);
 }

--- a/src/bin/pickpocket-batch-read.rs
+++ b/src/bin/pickpocket-batch-read.rs
@@ -2,7 +2,7 @@ extern crate hyper;
 extern crate rustc_serialize;
 extern crate pickpocket;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeSet};
 use std::env;
 use std::io::{BufReader, BufRead};
 
@@ -26,12 +26,12 @@ fn main() {
         url_id.insert(&reading_item.url(), id);
     }
 
-    let mut ids: Vec<&str> = Vec::new();
+    let mut ids: BTreeSet<&str> = BTreeSet::new();
 
     for line in BufReader::new(file).lines() {
         let url = line.expect("Couldn't read line from Buffered Reader");
         match url_id.get(&url as &str) {
-            Some(id) => ids.push(id),
+            Some(id) => { ids.insert(id); },
             None => println!("Url {} did not match", &url),
         }
     }

--- a/src/bin/pickpocket-batch-read.rs
+++ b/src/bin/pickpocket-batch-read.rs
@@ -2,7 +2,7 @@ extern crate hyper;
 extern crate rustc_serialize;
 extern crate pickpocket;
 
-use std::collections::{HashMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::io::{BufReader, BufRead};
 
@@ -21,7 +21,7 @@ fn main() {
 
     let reading_list = client.list_all();
 
-    let mut url_id: HashMap<&str, &str> = HashMap::new();
+    let mut url_id: BTreeMap<&str, &str> = BTreeMap::new();
     for (id, reading_item) in &reading_list.list {
         url_id.insert(&reading_item.url(), id);
     }

--- a/src/bin/pickpocket-fixup.rs
+++ b/src/bin/pickpocket-fixup.rs
@@ -24,6 +24,6 @@ fn main() {
         }
     }
 
-    client.mark_as_favorite(&favorites);
-    client.mark_as_read(&read);
+    client.mark_as_favorite(favorites);
+    client.mark_as_read(read);
 }

--- a/src/bin/pickpocket-fixup.rs
+++ b/src/bin/pickpocket-fixup.rs
@@ -2,6 +2,7 @@ extern crate hyper;
 extern crate rustc_serialize;
 extern crate pickpocket;
 
+use std::collections::BTreeSet;
 use pickpocket::{Status, FavoriteStatus};
 
 fn main() {
@@ -11,16 +12,16 @@ fn main() {
     };
 
     let reading_list = client.list_all();
-    let mut favorites : Vec<&str> = vec!();
-    let mut read : Vec<&str> = vec!();
+    let mut favorites: BTreeSet<&str> = BTreeSet::new();
+    let mut read: BTreeSet<&str> = BTreeSet::new();
 
     for (id, reading_item) in &reading_list.list {
         if reading_item.favorite() == FavoriteStatus::Favorited {
-            favorites.push(id)
+            favorites.insert(id);
         }
 
         if reading_item.status() == Status::Read {
-            read.push(id)
+            read.insert(id);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,13 @@ enum Action {
 #[derive(PartialEq)]
 pub enum FavoriteStatus {
     Favorited,
-    NotFavorited
+    NotFavorited,
 }
 
 #[derive(PartialEq)]
 pub enum Status {
     Read,
-    Unread
+    Unread,
 }
 
 impl Item {
@@ -113,15 +113,15 @@ impl Client {
             _ => "item_id",
         };
         let time = chrono::UTC::now().timestamp();
-        let actions: Vec<String> = ids.iter()
-                                      .map(|id| {
-                                          format!(r##"{{ "action": "{}", "{}": "{}", "time": "{}" }}"##,
-                                                  action_verb,
-                                                  item_key,
-                                                  id,
-                                                  time)
-                                      })
-                                      .collect();
+        let actions: Vec<String> = ids.into_iter()
+            .map(|id| {
+                format!(r##"{{ "action": "{}", "{}": "{}", "time": "{}" }}"##,
+                        action_verb,
+                        item_key,
+                        id,
+                        time)
+            })
+            .collect();
         let payload = format!(r##"{{ "consumer_key":"{}",
                                "access_token":"{}",
                                "actions": [{}]
@@ -138,11 +138,11 @@ impl Client {
         let client = hyper::Client::new();
 
         let mut res = client.post(method)
-                            .body(&payload)
-                            .header(ContentType::json())
-                            .header(Connection::close())
-                            .send()
-                            .expect(&format!("Coulnd't make request with payload: {}", &payload));
+            .body(&payload)
+            .header(ContentType::json())
+            .header(Connection::close())
+            .send()
+            .expect(&format!("Coulnd't make request with payload: {}", &payload));
 
         let mut body = String::new();
         res.read_to_string(&mut body).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,16 +67,22 @@ impl Item {
 }
 
 impl Client {
-    pub fn mark_as_read(&self, ids: &[&str]) {
-        self.modify(Action::Archive, &ids);
+    pub fn mark_as_read<'a, T>(&self, ids: T)
+        where T: IntoIterator<Item = &'a str>
+    {
+        self.modify(Action::Archive, ids);
     }
 
-    pub fn mark_as_favorite(&self, ids: &[&str]) {
-        self.modify(Action::Favorite, &ids);
+    pub fn mark_as_favorite<'a, T>(&self, ids: T)
+        where T: IntoIterator<Item = &'a str>
+    {
+        self.modify(Action::Favorite, ids);
     }
 
-    pub fn add_urls(&self, urls: &[&str]) {
-        self.modify(Action::Add, &urls);
+    pub fn add_urls<'a, T>(&self, urls: T)
+        where T: IntoIterator<Item = &'a str>
+    {
+        self.modify(Action::Add, urls);
     }
 
     pub fn list_all(&self) -> ReadingListResponse {
@@ -93,7 +99,9 @@ impl Client {
         json::decode(&response).expect("Couldn't parse /get response")
     }
 
-    fn modify(&self, action: Action, ids: &[&str]) {
+    fn modify<'a, T>(&self, action: Action, ids: T)
+        where T: IntoIterator<Item = &'a str>
+    {
         let method = url("/send");
         let action_verb = match action {
             Action::Favorite => "favorite",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use self::hyper::header::{Connection, ContentType};
 use self::hyper::Url;
 use self::rustc_serialize::json;
 use self::rustc_serialize::Decoder;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::Read;
 
 mod auth;
@@ -23,7 +23,7 @@ pub struct Item {
 
 #[derive(RustcDecodable)]
 pub struct ReadingListResponse {
-    pub list: HashMap<String, Item>,
+    pub list: BTreeMap<String, Item>,
 }
 
 enum Action {


### PR DESCRIPTION
Instead of using a Vec, change everything into Set's.

This PR also changes the signature of the functions from taking slices, into a more generic Trait based on Iterators. This make the API more ergonomic, as many other structures could be converted into Iterators, but not always into slices.

There are more info on each commit.
