### PR TITLE
Cleanup URLs from hashes

### DIFF
--- a/src/bin/pickpocket-batch-favorite.rs
+++ b/src/bin/pickpocket-batch-favorite.rs
@@ -22,8 +22,10 @@ fn main() {
     let reading_list = client.list_all();
 
     let mut url_id: BTreeMap<&str, &str> = BTreeMap::new();
+    let mut cleanurl_id: BTreeMap<String, &str> = BTreeMap::new();
     for (id, reading_item) in &reading_list.list {
         url_id.insert(reading_item.url(), id);
+        cleanurl_id.insert(pickpocket::cleanup_url(reading_item.url()), id);
     }
 
     let mut ids: BTreeSet<&str> = BTreeSet::new();
@@ -34,7 +36,14 @@ fn main() {
             Some(id) => {
                 ids.insert(id);
             }
-            None => println!("Url {} did not match", &url),
+            None => {
+                match cleanurl_id.get(&pickpocket::cleanup_url(&url)) {
+                    Some(id) => {
+                        ids.insert(id);
+                    }
+                    None => println!("Url {} did not match", &url)
+                }
+            }
         }
     }
 

--- a/src/bin/pickpocket-batch-read.rs
+++ b/src/bin/pickpocket-batch-read.rs
@@ -22,8 +22,11 @@ fn main() {
     let reading_list = client.list_all();
 
     let mut url_id: BTreeMap<&str, &str> = BTreeMap::new();
+    let mut cleanurl_id: BTreeMap<String, &str> = BTreeMap::new();
+
     for (id, reading_item) in &reading_list.list {
         url_id.insert(reading_item.url(), id);
+        cleanurl_id.insert(pickpocket::cleanup_url(reading_item.url()), id);
     }
 
     let mut ids: BTreeSet<&str> = BTreeSet::new();
@@ -34,7 +37,14 @@ fn main() {
             Some(id) => {
                 ids.insert(id);
             }
-            None => println!("Url {} did not match", &url),
+            None => {
+                match cleanurl_id.get(&pickpocket::cleanup_url(&url)) {
+                    Some(id) => {
+                        ids.insert(id);
+                    }
+                    None => println!("Url {} did not match", &url)
+                }
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,3 +148,38 @@ impl Client {
         body
     }
 }
+
+pub fn cleanup_url(url: &str) -> String {
+    let parsed = Url::parse(url).expect("Could not parse cleanup url");
+    format!("{}://{}{}", parsed.scheme(), parsed.host_str().expect("Cleaned up an url without a host") , parsed.path())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_clean_url_hash() {
+        let url_ = "http://example.com#asdfas.fsa";
+        assert_eq!(cleanup_url(url_), "http://example.com/");
+    }
+
+    #[test]
+    fn test_clean_url_query() {
+        let url_ = "http://example.com?";
+        assert_eq!(cleanup_url(url_), "http://example.com/");
+    }
+
+    #[test]
+    fn test_clean_url_keep_same_url() {
+        let url_ = "http://another.example.com";
+        assert_eq!(cleanup_url(url_), "http://another.example.com/");
+    }
+
+    #[test]
+    fn test_clean_url_keep_https() {
+        let url = "https://another.example.com";
+        assert_eq!(cleanup_url(url), "https://another.example.com/");
+    }
+}
+


### PR DESCRIPTION
Some websites uses the hash or query strings to track where the user
came from, which campaign provided the link and so on.

Some examples:
- Medium
- Buffer twitter posts
- Blogspot (which changes the domain completely)

This commit try to address this by keeping another set with cleaned up
URls, which has no query strings or hash.

The idea to use a set is to exchange memory for speed, as it will locate
the content faster than looping all the time. This will only be used if
the as-given lookup fails.
