### PR TITLE
Handle www redirection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ fn start_domain_from(url: &str) -> usize {
 pub fn cleanup_url(url: &str) -> String {
     let parsed = Url::parse(url).expect("Could not parse cleanup url");
     let current_host = parsed.host_str().expect("Cleaned up an url without a host");
-    let starts_from = start_domain_from(&current_host);
+    let starts_from = start_domain_from(current_host);
 
     format!("{}://{}{}",
             parsed.scheme(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,13 +158,22 @@ fn fixup_blogspot(url: &str) -> String {
     }
 }
 
+fn start_domain_from(url: &str) -> usize {
+    if url.starts_with("www.") {
+        4
+    } else {
+        0
+    }
+}
+
 pub fn cleanup_url(url: &str) -> String {
     let parsed = Url::parse(url).expect("Could not parse cleanup url");
     let current_host = parsed.host_str().expect("Cleaned up an url without a host");
+    let starts_from = start_domain_from(&current_host);
 
     format!("{}://{}{}",
             parsed.scheme(),
-            fixup_blogspot(current_host),
+            fixup_blogspot(&current_host[starts_from..]),
             parsed.path())
 }
 
@@ -206,6 +215,13 @@ mod test {
     #[test]
     fn test_cleanup_blogspot_second_tld() {
         let url = "https://this-is-a.blogspot.com.br/asdf/asdf/asdf?asdf=1";
+        assert_eq!(cleanup_url(url),
+                   "https://this-is-a.blogspot.com/asdf/asdf/asdf");
+    }
+
+    #[test]
+    fn test_cleanup_www() {
+        let url = "https://www.this-is-a.blogspot.com.br/asdf/asdf/asdf?asdf=1";
         assert_eq!(cleanup_url(url),
                    "https://this-is-a.blogspot.com/asdf/asdf/asdf");
     }


### PR DESCRIPTION
Some websites redirects to the www version when being visited.
This commit removes the www. string from the start of the domain when
cleaning it up.
