### PR TITLE
Extracts the batch logic into a common file

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,0 +1,75 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::fs::File;
+use std::io::{BufReader, BufRead, Lines};
+
+pub struct BatchApp {
+    pub client: Client,
+    url_id: BTreeMap<String, String>,
+    clean_url_id: BTreeMap<String, String>,
+    file_name: String,
+}
+
+use cleanup_url;
+use cli::*;
+
+impl Default for BatchApp {
+    fn default() -> Self {
+        let readlist_file_name = env::args()
+            .skip(1)
+            .next()
+            .expect("Expected an reading list file as argument");
+
+        let cache_file_name = env::args()
+            .skip(2)
+            .next()
+            .expect("Expected an cache as argument");
+
+        let client = match client_from_env_vars() {
+            Ok(client) => client,
+            Err(e) => panic!("It wasn't possible to initialize a Pocket client\n{}", e),
+        };
+
+        let cache_client = match FileClient::from_cache(&cache_file_name) {
+            Ok(client) => client,
+            Err(e) => panic!("It wasn't possible to initialize a Pocket cache\n{}", e),
+        };
+
+        let reading_list = cache_client.list_all();
+
+        let mut url_id = BTreeMap::new();
+        let mut cleanurl_id = BTreeMap::new();
+        for (id, reading_item) in reading_list {
+            url_id.insert(reading_item.url().into(), id.clone());
+            cleanurl_id.insert(cleanup_url(reading_item.url()), id.clone());
+        }
+
+        BatchApp {
+            url_id: url_id,
+            clean_url_id: cleanurl_id,
+            client: client,
+            file_name: readlist_file_name,
+        }
+    }
+}
+
+impl BatchApp {
+    pub fn get(&self, url: &str) -> Option<&str> {
+        match self.url_id.get(url) {
+            Some(x) => Some(x),
+            None => {
+                match self.clean_url_id.get(&cleanup_url(url)) {
+                    Some(x) => Some(x),
+                    None => None,
+                }
+            }
+        }
+    }
+
+    pub fn file_lines(&self) -> Lines<BufReader<File>> {
+        let file = File::open(&self.file_name)
+            .expect(&format!("Couldn't open {}", &self.file_name));
+
+        BufReader::new(file).lines()
+    }
+}

--- a/src/bin/pickpocket-batch-add.rs
+++ b/src/bin/pickpocket-batch-add.rs
@@ -1,46 +1,17 @@
 extern crate pickpocket;
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::env;
-use std::io::{BufReader, BufRead};
+use std::collections::BTreeSet;
 
-use pickpocket::cli::*;
+use pickpocket::batch::BatchApp;
 
 fn main() {
-    let file_name = env::args()
-        .skip(1)
-        .next()
-        .expect("Expected an file as argument");
-
-    let cache_file_name = env::args()
-        .skip(2)
-        .next()
-        .expect("Expected an cache as argument");
-
-    let file = std::fs::File::open(&file_name).expect(&format!("Couldn't open {}", &file_name));
-
-    let client = match pickpocket::cli::client_from_env_vars() {
-        Ok(client) => client,
-        Err(e) => panic!("It wasn't possible to initialize a Pocket client\n{}", e),
-    };
-
-    let cache_client = match FileClient::from_cache(&cache_file_name) {
-        Ok(client) => client,
-        Err(e) => panic!("It wasn't possible to initialize a Pocket cache\n{}", e),
-    };
-
-    let reading_list = cache_client.list_all();
-
-    let mut url_id: BTreeMap<&str, &str> = BTreeMap::new();
-    for (id, reading_item) in reading_list {
-        url_id.insert(reading_item.url(), id);
-    }
+    let app = BatchApp::default();
 
     let mut urls: BTreeSet<String> = BTreeSet::new();
 
-    for line in BufReader::new(file).lines() {
-        let url = line.expect("Couldn't read line from Buffered Reader");
-        match url_id.get(&url as &str) {
+    for line in app.file_lines() {
+        let url = line.expect("Could not read line");
+        match app.get(&url as &str) {
             None => {
                 urls.insert(url);
             }
@@ -48,5 +19,5 @@ fn main() {
         }
     }
 
-    client.add_urls(urls.iter().map(AsRef::as_ref));
+    app.client.add_urls(urls.iter().map(AsRef::as_ref));
 }

--- a/src/bin/pickpocket-batch-favorite.rs
+++ b/src/bin/pickpocket-batch-favorite.rs
@@ -1,63 +1,23 @@
 extern crate pickpocket;
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::env;
-use std::fs::File;
-use std::io::{BufReader, BufRead};
+use std::collections::BTreeSet;
 
-use pickpocket::cli::*;
+use pickpocket::batch::BatchApp;
 
 fn main() {
-    let readlist_file_name = env::args()
-        .skip(1)
-        .next()
-        .expect("Expected an reading list file as argument");
-
-    let cache_file_name = env::args()
-        .skip(2)
-        .next()
-        .expect("Expected an cache as argument");
-
-    let readlist_file = File::open(&readlist_file_name)
-        .expect(&format!("Couldn't open {}", &readlist_file_name));
-
-    let client = match client_from_env_vars() {
-        Ok(client) => client,
-        Err(e) => panic!("It wasn't possible to initialize a Pocket client\n{}", e),
-    };
-
-    let cache_client = match FileClient::from_cache(&cache_file_name) {
-        Ok(client) => client,
-        Err(e) => panic!("It wasn't possible to initialize a Pocket cache\n{}", e),
-    };
-
-    let reading_list = cache_client.list_all();
-
-    let mut url_id: BTreeMap<&str, &str> = BTreeMap::new();
-    let mut cleanurl_id: BTreeMap<String, &str> = BTreeMap::new();
-    for (id, reading_item) in reading_list {
-        url_id.insert(reading_item.url(), id);
-        cleanurl_id.insert(pickpocket::cleanup_url(reading_item.url()), id);
-    }
+    let app = BatchApp::default();
 
     let mut ids: BTreeSet<&str> = BTreeSet::new();
 
-    for line in BufReader::new(readlist_file).lines() {
-        let url = line.expect("Couldn't read line from Buffered Reader");
-        match url_id.get(&url as &str) {
+    for line in app.file_lines() {
+        let url = line.expect("Could not read line");
+        match app.get(&url as &str) {
             Some(id) => {
                 ids.insert(id);
             }
-            None => {
-                match cleanurl_id.get(&pickpocket::cleanup_url(&url)) {
-                    Some(id) => {
-                        ids.insert(id);
-                    }
-                    None => println!("Url {} did not match", &url),
-                }
-            }
+            None => println!("Url {} did not match", &url),
         }
     }
 
-    client.mark_as_favorite(ids);
+    app.client.mark_as_favorite(ids);
 }

--- a/src/bin/pickpocket-batch-read.rs
+++ b/src/bin/pickpocket-batch-read.rs
@@ -1,63 +1,23 @@
 extern crate pickpocket;
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::env;
-use std::fs::File;
-use std::io::{BufReader, BufRead};
+use std::collections::BTreeSet;
 
-use pickpocket::cli::*;
+use pickpocket::batch::BatchApp;
 
 fn main() {
-    let readlist_file_name = env::args()
-        .skip(1)
-        .next()
-        .expect("Expected an reading list file as argument");
-
-    let cache_file_name = env::args()
-        .skip(2)
-        .next()
-        .expect("Expected an cache as argument");
-
-    let readlist_file = File::open(&readlist_file_name)
-        .expect(&format!("Couldn't open {}", &readlist_file_name));
-
-    let client = match client_from_env_vars() {
-        Ok(client) => client,
-        Err(e) => panic!("It wasn't possible to initialize a Pocket client\n{}", e),
-    };
-
-    let cache_client = match FileClient::from_cache(&cache_file_name) {
-        Ok(client) => client,
-        Err(e) => panic!("It wasn't possible to initialize a Pocket cache\n{}", e),
-    };
-
-    let reading_list = cache_client.list_all();
-
-    let mut url_id: BTreeMap<&str, &str> = BTreeMap::new();
-    let mut cleanurl_id: BTreeMap<String, &str> = BTreeMap::new();
-    for (id, reading_item) in reading_list {
-        url_id.insert(reading_item.url(), id);
-        cleanurl_id.insert(pickpocket::cleanup_url(reading_item.url()), id);
-    }
+    let app = BatchApp::default();
 
     let mut ids: BTreeSet<&str> = BTreeSet::new();
 
-    for line in BufReader::new(readlist_file).lines() {
-        let url = line.expect("Couldn't read line from Buffered Reader");
-        match url_id.get(&url as &str) {
+    for line in app.file_lines() {
+        let url = line.expect("Could not read line");
+        match app.get(&url as &str) {
             Some(id) => {
                 ids.insert(id);
             }
-            None => {
-                match cleanurl_id.get(&pickpocket::cleanup_url(&url)) {
-                    Some(id) => {
-                        ids.insert(id);
-                    }
-                    None => println!("Url {} did not match", &url),
-                }
-            }
+            None => println!("Url {} did not match", &url),
         }
     }
 
-    client.mark_as_read(ids);
+    app.client.mark_as_read(ids);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use rustc_serialize::json::DecoderError;
 
 mod auth;
 pub mod cli;
+pub mod batch;
 pub use auth::*;
 
 const DEFAULT_COUNT: u32 = 5000;


### PR DESCRIPTION
All the batch commands have a similar structure:
- Read from a cache
- Read the content from a file
- Verify if the content of the file is on the cache
- Fallback to a clean URL if the strict search does not work
- Act on the content, either the ID or the URL

Only the last part changes depending on the command.
This commit extracts the logic into a BatchApp, which is responsible to
produce the in-memory content and centralize the matching logic.
