### PR TITLE
Configure travis to build binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
             # Transparent emulation
             - qemu-user-static
             - binfmt-support
+            # Added packages
+            - libssl-dev:arm64
+            - libcrypto++-dev:arm64
     - os: linux
       rust: stable
       env: TARGET=armv7-unknown-linux-gnueabihf
@@ -47,6 +50,9 @@ matrix:
             # Transparent emulation
             - qemu-user-static
             - binfmt-support
+            # Added packages
+            - libssl-dev:armhf
+            - libcrypto++-dev:armhf
     - os: osx
       rust: stable
       env: TARGET=i686-apple-darwin
@@ -58,15 +64,32 @@ matrix:
           packages: &i686_unknown_linux_gnu
             # Cross compiler and cross compiled C libraries
             - gcc-multilib
+            # Added packages
+            - libssl-dev:i386
+            - libcrypto++-dev:i386
     - os: osx
       rust: stable
       env: TARGET=x86_64-apple-darwin
     - os: linux
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
+      addons:
+        apt:
+          packages:
+            # Added packages
+            - libssl-dev
+            - libcrypto++-dev
     - os: linux
       rust: stable
       env: TARGET=x86_64-unknown-linux-musl
+      addons:
+        apt:
+          packages:
+            # Added packages
+            - libssl-dev
+            - libcrypto++-dev
+            - musl-dev
+            - musl-tools
 
 before_install:
   - export PATH="$PATH:$HOME/.cargo/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,8 +92,6 @@ matrix:
             # Added packages
             - libssl-dev
             - libcrypto++-dev
-            - musl-dev
-            - musl-tools
 
 before_install:
   - export PATH="$PATH:$HOME/.cargo/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
       # Extra packages only for this job
       addons:
         apt:
+          sources:
+            sourceline: 'deb http://ports.ubuntu.com/ubuntu-ports/ trusty main universe multiverse restricted'
           packages: &aarch64_unknown_linux_gnu
             # Transparent emulation
             - qemu-user-static
@@ -42,6 +44,8 @@ matrix:
       sudo: required
       addons:
         apt:
+          sources:
+            sourceline: 'deb http://ports.ubuntu.com/ubuntu-ports/ trusty main universe multiverse restricted'
           packages: &armv7_unknown_linux_gnueabihf
             # Cross compiler and cross compiled C libraries
             - gcc-arm-linux-gnueabihf

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,44 +19,6 @@ env:
 matrix:
   include:
     # Stable channel
-    - os: linux
-      rust: stable
-      env: TARGET=aarch64-unknown-linux-gnu
-      # need Trusty because the glibc in Precise is too old and doesn't support 64-bit arm
-      dist: trusty
-      sudo: required
-      # Extra packages only for this job
-      addons:
-        apt:
-          sources:
-            sourceline: 'deb http://ports.ubuntu.com/ubuntu-ports/ trusty main universe multiverse restricted'
-          packages: &aarch64_unknown_linux_gnu
-            # Transparent emulation
-            - qemu-user-static
-            - binfmt-support
-            # Added packages
-            - libssl-dev:arm64
-            - libcrypto++-dev:arm64
-    - os: linux
-      rust: stable
-      env: TARGET=armv7-unknown-linux-gnueabihf
-      # sudo is needed for binfmt_misc, which is needed for transparent user qemu emulation
-      sudo: required
-      addons:
-        apt:
-          sources:
-            sourceline: 'deb http://ports.ubuntu.com/ubuntu-ports/ trusty main universe multiverse restricted'
-          packages: &armv7_unknown_linux_gnueabihf
-            # Cross compiler and cross compiled C libraries
-            - gcc-arm-linux-gnueabihf
-            - libc6-armhf-cross
-            - libc6-dev-armhf-cross
-            # Transparent emulation
-            - qemu-user-static
-            - binfmt-support
-            # Added packages
-            - libssl-dev:armhf
-            - libcrypto++-dev:armhf
     - os: osx
       rust: stable
       env: TARGET=i686-apple-darwin
@@ -77,15 +39,6 @@ matrix:
     - os: linux
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
-      addons:
-        apt:
-          packages:
-            # Added packages
-            - libssl-dev
-            - libcrypto++-dev
-    - os: linux
-      rust: stable
-      env: TARGET=x86_64-unknown-linux-musl
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,117 @@
 language: rust
-rust:
-  - stable
-  - beta
-  - nightly
+cache: cargo
+
+env:
+  global:
+    # This will be part of the release tarball
+    # TODO change the project name
+    - PROJECT_NAME=pickpocket
+    # TODO comment out this variable if you don't want to build .deb packages on all the targets.
+    - MAKE_DEB=yes
+    # TODO update these two variables. They are part of the .deb package metadata
+    - DEB_MAINTAINER="Bruno Tavares <@bltavares>"
+    - DEB_DESCRIPTION="Pocket command line manager"
+
+# AFAICT There are a few ways to set up the build jobs. This one is not the DRYest but I feel is the
+# easiest to reason about.
+# TODO Feel free to remove the channels/targets you don't need
+# NOTE Make *sure* you don't remove a reference (&foo) if you are going to dereference it (*foo)
 matrix:
-  allow_failures:
-    - rust: nightly
+  include:
+    # Stable channel
+    - os: linux
+      rust: stable
+      env: TARGET=aarch64-unknown-linux-gnu
+      # need Trusty because the glibc in Precise is too old and doesn't support 64-bit arm
+      dist: trusty
+      sudo: required
+      # Extra packages only for this job
+      addons:
+        apt:
+          packages: &aarch64_unknown_linux_gnu
+            # Transparent emulation
+            - qemu-user-static
+            - binfmt-support
+    - os: linux
+      rust: stable
+      env: TARGET=armv7-unknown-linux-gnueabihf
+      # sudo is needed for binfmt_misc, which is needed for transparent user qemu emulation
+      sudo: required
+      addons:
+        apt:
+          packages: &armv7_unknown_linux_gnueabihf
+            # Cross compiler and cross compiled C libraries
+            - gcc-arm-linux-gnueabihf
+            - libc6-armhf-cross
+            - libc6-dev-armhf-cross
+            # Transparent emulation
+            - qemu-user-static
+            - binfmt-support
+    - os: osx
+      rust: stable
+      env: TARGET=i686-apple-darwin
+    - os: linux
+      rust: stable
+      env: TARGET=i686-unknown-linux-gnu
+      addons:
+        apt:
+          packages: &i686_unknown_linux_gnu
+            # Cross compiler and cross compiled C libraries
+            - gcc-multilib
+    - os: osx
+      rust: stable
+      env: TARGET=x86_64-apple-darwin
+    - os: linux
+      rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu
+    - os: linux
+      rust: stable
+      env: TARGET=x86_64-unknown-linux-musl
+
+before_install:
+  - export PATH="$PATH:$HOME/.cargo/bin"
+
+install:
+  - bash scripts/install.sh
+
+script:
+  - bash scripts/script.sh
+
+before_deploy:
+  - bash scripts/before_deploy.sh
+
+deploy:
+  provider: releases
+  # TODO Regenerate this api_key for your project, this one won't work for you. Here's how:
+  # - Go to 'https://github.com/settings/tokens/new' and generate a Token with only the
+  # `public_repo` scope enabled
+  # - Call `travis encrypt $github_token` where $github_token is the token you got in the previous
+  # step and `travis` is the official Travis CI gem (see https://rubygems.org/gems/travis/)
+  # - Enter the "encrypted value" below
+  api_key:
+    secure: "ICxMkUIseLvzdnE1JCqipkYQFa43pC2Sv44HA3CcI/8bgOHNbRD81d69CnHnbXZeOAdPbX6TiMKGI3UhDYpHS65sH8Z7npr51zwcC7VMHsCzOFvBcA0fWoXyEZ0CZErD6gYrzHZnfm2TDQs0p9z8x69ULY6OaQS3UUhTl6lFHtOdWXT14lirppar80HIq8+d3k8jbsxp71mTqHqcWyGV9T7Aq6wJU0c+0nNM2W6S+nVP1FUOjF4gNrtXrtBKyY6e1vTd7nz7ZGntdQeFFjAqDLOZz+0F3k3+RW2F8WJZA/nPvREFMaBiM1+ULD7JAafrh+c+CBbugPSOYpQfM7Oqn+TCdm3UFpMu4kicJFYuDj8GTw5vDi8tS9T93OfCeAYbGJsAAFv4VJYiRUxrhtm0JksEZpfT5fNo+oqi4SCmQhtz/DIcZ9FYrKEtb9A1XmcoYkmHHHIffXRtiBTQjgwoQoEA5qZPalsS/RBiSkXvlzezu1Hy08Fw+B9avxcmMWtKxzEJq9RPC6ucbBXjA09IxJjkDB3hdSx8ciQsC4QYI/U3Yhp90xzPnpOf1HU6/9xOg9zHIknPu5bB9/tk3CqThSrA8emc5oJJAsk05F/0X/ERZ3I5f3i2werevq+fp7RElzA0yPG1oFrklEPZOD2x/VAYXrrHyWNuX5kKDfjtOGE="
+  file_glob: true
+  file: ${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.*
+  # don't delete the artifacts from previous phases
+  skip_cleanup: true
+  # deploy when a new tag is pushed
+  on:
+    # channel to use to produce the release artifacts
+    # NOTE make sure you only release *once* per target
+    # TODO you may want to pick a different channel
+    condition: $TRAVIS_RUST_VERSION = stable
+    tags: true
+
+branches:
+  only:
+    # Pushes and PR to the master branch
+    - master
+    # IMPORTANT Ruby regex to match tags. Required, or travis won't trigger deploys when a new tag
+    # is pushed. This regex matches semantic versions like v1.2.3-rc4+2016.02.22
+    - /^v\d+\.\d+\.\d+.*$/
+
+notifications:
+  email:
+    on_success: never
+
 after_success: curl https://raw.githubusercontent.com/bltavares/travis-doc-upload/master/travis-doc-upload.sh | sh

--- a/scripts/before_deploy.sh
+++ b/scripts/before_deploy.sh
@@ -1,0 +1,66 @@
+# `before_deploy` phase: here we package the build artifacts
+
+set -ex
+
+. $(dirname $0)/utils.sh
+
+# Generate artifacts for release
+mk_artifacts() {
+    cargo build --target $TARGET --release
+}
+
+mk_tarball() {
+    # create a "staging" directory
+    local td=$(mktempd)
+    local out_dir=$(pwd)
+
+    # NOTE All Cargo build artifacts will be under the 'target/$TARGET/{debug,release}'
+    cp target/$TARGET/release/pickpocket-* $td
+
+    pushd $td
+
+    # release tarball will look like 'rust-everywhere-v1.2.3-x86_64-unknown-linux-gnu.tar.gz'
+    tar czf $out_dir/${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz *
+
+    popd
+    rm -r $td
+}
+
+# Package your artifacts in a .deb file
+# NOTE right now you can only package binaries using the `dobin` command. Simply call
+# `dobin [file..]` to include one or more binaries in your .deb package. I'll add more commands to
+# install other things like manpages (`doman`) as the needs arise.
+# XXX This .deb packaging is minimal -- just to make your app installable via `dpkg` -- and doesn't
+# fully conform to Debian packaging guideliens (`lintian` raises a few warnings/errors)
+mk_deb() {
+    dobin target/$TARGET/release/pickpocket-*
+}
+
+main() {
+    mk_artifacts
+    mk_tarball
+
+    if [ $TRAVIS_OS_NAME = linux ]; then
+        if [ ! -z $MAKE_DEB ]; then
+            dtd=$(mktempd)
+            mkdir -p $dtd/debian/usr/bin
+
+            mk_deb
+
+            mkdir -p $dtd/debian/DEBIAN
+            cat >$dtd/debian/DEBIAN/control <<EOF
+Package: $PROJECT_NAME
+Version: ${TRAVIS_TAG#v}
+Architecture: $(architecture $TARGET)
+Maintainer: $DEB_MAINTAINER
+Description: $DEB_DESCRIPTION
+EOF
+
+            fakeroot dpkg-deb --build $dtd/debian
+            mv $dtd/debian.deb $PROJECT_NAME-$TRAVIS_TAG-$TARGET.deb
+            rm -r $dtd
+        fi
+    fi
+}
+
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,58 @@
+# `install` phase: install stuff needed for the `script` phase
+
+set -ex
+
+. $(dirname $0)/utils.sh
+
+install_c_toolchain() {
+    case $TARGET in
+        aarch64-unknown-linux-gnu)
+            sudo apt-get install -y --no-install-recommends \
+                 gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
+            ;;
+        *)
+            # For other targets, this is handled by addons.apt.packages in .travis.yml
+            ;;
+    esac
+}
+
+install_rustup() {
+    # uninstall the rust toolchain installed by travis, we are going to use rustup
+    sh ~/rust/lib/rustlib/uninstall.sh
+
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=$TRAVIS_RUST_VERSION
+
+    rustc -V
+    cargo -V
+}
+
+install_standard_crates() {
+    if [ $(host) != "$TARGET" ]; then
+        rustup target add $TARGET
+    fi
+}
+
+configure_cargo() {
+    local prefix=$(gcc_prefix)
+
+    if [ ! -z $prefix ]; then
+        # information about the cross compiler
+        ${prefix}gcc -v
+
+        # tell cargo which linker to use for cross compilation
+        mkdir -p .cargo
+        cat >>.cargo/config <<EOF
+[target.$TARGET]
+linker = "${prefix}gcc"
+EOF
+    fi
+}
+
+main() {
+    install_c_toolchain
+    install_rustup
+    install_standard_crates
+    configure_cargo
+}
+
+main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,6 +10,10 @@ install_c_toolchain() {
             sudo apt-get install -y --no-install-recommends \
                  gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
             ;;
+        x86_64-unknown-linux-musl)
+            sudo apt-get install -y --no-install-recommends \
+              musl-dev musl-tools
+            ;;
         *)
             # For other targets, this is handled by addons.apt.packages in .travis.yml
             ;;

--- a/scripts/script.sh
+++ b/scripts/script.sh
@@ -1,0 +1,59 @@
+# `script` phase: you usually build, test and generate docs in this phase
+
+set -ex
+
+# NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
+# This has been fixed in the nightly channel but it would take a while to reach the other channels
+disable_cross_doctests() {
+  local host
+
+  case "$TRAVIS_OS_NAME" in
+    linux)
+      host=x86_64-unknown-linux-gnu
+      ;;
+    osx)
+      host=x86_64-apple-darwin
+      ;;
+  esac
+
+  if [ "$host" != "$TARGET" ] && [ "$CHANNEL" != "nightly" ]; then
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      brew install gnu-sed --default-names
+    fi
+
+    find src -name '*.rs' -type f | xargs sed -i -e 's:\(//.\s*```\):\1 ignore,:g'
+  fi
+}
+
+# PROTIP Always pass `--target $TARGET` to cargo commands, this makes cargo output build artifacts
+# to target/$TARGET/{debug,release} which can reduce the number of needed conditionals in the
+# `before_deploy`/packaging phase
+run_test_suite() {
+  case $TARGET in
+    # configure emulation for transparent execution of foreign binaries
+    arm*-unknown-linux-gnueabihf)
+      export QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf
+      ;;
+    *)
+      ;;
+  esac
+
+  if [ ! -z "$QEMU_LD_PREFIX" ]; then
+    # Run tests on a single thread when using QEMU user emulation
+    export RUST_TEST_THREADS=1
+  fi
+
+  cargo build --target $TARGET --verbose
+  cargo run --target $TARGET --help
+  cargo test --target $TARGET
+
+  # sanity check the file type
+  file target/$TARGET/debug/pickpocket-*
+}
+
+main() {
+  disable_cross_doctests
+  run_test_suite
+}
+
+main

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,56 @@
+mktempd() {
+  echo $(mktemp -d 2>/dev/null || mktemp -d -t tmp)
+}
+
+host() {
+  case "$TRAVIS_OS_NAME" in
+    linux)
+      echo x86_64-unknown-linux-gnu
+      ;;
+    osx)
+      echo x86_64-apple-darwin
+      ;;
+  esac
+}
+
+gcc_prefix() {
+  case "$TARGET" in
+    aarch64-unknown-linux-gnu)
+      echo aarch64-linux-gnu-
+      ;;
+    arm*-gnueabihf)
+      echo arm-linux-gnueabihf-
+      ;;
+    *)
+      return
+      ;;
+  esac
+}
+
+dobin() {
+  [ -z $MAKE_DEB ] && die 'dobin: $MAKE_DEB not set'
+  [ $# -lt 1 ] && die "dobin: at least one argument needed"
+
+  local f prefix=$(gcc_prefix)
+  for f in "$@"; do
+    install -m0755 $f $dtd/debian/usr/bin/
+    ${prefix}strip -s $dtd/debian/usr/bin/$(basename $f)
+  done
+}
+
+architecture() {
+  case $1 in
+    x86_64-unknown-linux-gnu|x86_64-unknown-linux-musl)
+      echo amd64
+      ;;
+    i686-unknown-linux-gnu|i686-unknown-linux-musl)
+      echo i386
+      ;;
+    arm*-unknown-linux-gnueabihf)
+      echo armhf
+      ;;
+    *)
+      die "architecture: unexpected target $TARGET"
+      ;;
+  esac
+}


### PR DESCRIPTION
This commit changes the travis script to build binaries and releases
across multiple platforms, as well as package the application.

Based on https://github.com/japaric/rust-everywhere
