### PR TITLE
Adds information about the full URL and Status

### DIFF
--- a/src/bin/pickpocket-inspect.rs
+++ b/src/bin/pickpocket-inspect.rs
@@ -16,8 +16,10 @@ fn main() {
     let reading_list = client.list_all();
 
     for reading_item in reading_list.values() {
-        println!("{title} | {url}",
-                 url = pickpocket::cleanup_url(reading_item.url()),
-                 title = reading_item.title());
+        println!("{title} | {url} | {clean} | {status}",
+                 url = reading_item.url(),
+                 clean = pickpocket::cleanup_url(reading_item.url()),
+                 title = reading_item.title(),
+                 status = reading_item.status());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use hyper::Url;
 use rustc_serialize::json;
 use std::collections::BTreeMap;
 use std::io::Read;
+use std::fmt::{Display, Formatter, Result};
 
 use rustc_serialize::json::DecoderError;
 
@@ -58,6 +59,17 @@ pub enum FavoriteStatus {
 pub enum Status {
     Read,
     Unread,
+}
+
+impl Display for Status {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f,
+               "{}",
+               match *self {
+                   Status::Read => "Read",
+                   Status::Unread => "Unread",
+               })
+    }
 }
 
 impl Item {


### PR DESCRIPTION
To better script other tools around the inspect information, we need the
status, if either read or unread.

Also, some links like YouTube rely on the query param to identify the
video, and we were outputing only the clean url, which does not show the
id.
